### PR TITLE
refactor: update aptos-core deps to latest version

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,7 +1,3 @@
-[submodule "deps/aptos-core"]
-	path = deps/aptos-core
-	url = https://github.com/aptos-labs/aptos-core.git
-	branch = testnet
 [submodule "apps/bridge-evm/lib/forge-std"]
 	path = apps/bridge-evm/lib/forge-std
 	url = https://github.com/foundry-rs/forge-std

--- a/layerzero-common/Move.toml
+++ b/layerzero-common/Move.toml
@@ -5,5 +5,7 @@ version = "0.0.1"
 [addresses]
 layerzero_common = "_"
 
-[dependencies]
-AptosFramework = { local = "../deps/aptos-core/aptos-move/framework/aptos-framework" }
+[dependencies.AptosFramework]
+git = "https://github.com/aptos-labs/aptos-core.git"
+subdir = "aptos-move/framework/aptos-framework"
+rev = "895ae28e4a105430d8b9d2ce2f6e48c3b2c7fcf0"

--- a/zro/Move.toml
+++ b/zro/Move.toml
@@ -5,5 +5,7 @@ version = "0.0.1"
 [addresses]
 zro = "_"
 
-[dependencies]
-MoveStdlib = { local = "../deps/aptos-core/aptos-move/framework/move-stdlib" }
+[dependencies.MoveStdlib]
+git = "https://github.com/aptos-labs/aptos-core.git"
+subdir = "aptos-move/framework/move-stdlib"
+rev = "895ae28e4a105430d8b9d2ce2f6e48c3b2c7fcf0"


### PR DESCRIPTION
updated `aptos-core` dependency to dynamically use latest version rather than rely on specific commit found in the /deps folder. This upgrade allows for integration with other protocols which use the latest versions of `aptos-core`, who may face incompatibility issues with older `aptos-core` versions.

Description of error:
when importing layerzero in thala repository as such:

[dependencies.layerzero]
git = "https://github.com/LayerZero-Labs/LayerZero-Aptos-Contract.git"
subdir = "layerzero/"
rev = "main"

we receive this error:

{
  "Error": "Move compilation failed: Unable to resolve packages for package 'thala-protocol-v1': While resolving dependency 'layerzero' in package 'thala-protocol-v1': Unable to resolve package dependency 'layerzero': While resolving dependency 'executor_auth' in package 'layerzero': Unable to resolve package dependency 'executor_auth': While resolving dependency 'layerzero_common' in package 'executor_auth': Unable to resolve package dependency 'layerzero_common': While resolving dependency 'AptosFramework' in package 'layerzero_common': While processing dependency 'AptosFramework': Unable to find package manifest for 'AptosFramework' at \"/Users/lawsongraham/.move/https___github_com_LayerZero-Labs_LayerZero-Aptos-Contract_git_main/layerzero/../executor/executor-auth/../../layerzero-common/../deps/aptos-core/aptos-move/framework/aptos-framework\""
}