### PR TITLE
Fix Counter module

### DIFF
--- a/apps/counter/sources/counter.move
+++ b/apps/counter/sources/counter.move
@@ -69,7 +69,8 @@ module counter::counter {
         lz_receive_internal(chain_id, src_address, payload);
     }
 
-    public entry fun lz_receive_types(_src_chain_id: u64, _src_address: vector<u8>, _payload: vector<u8>) : vector<type_info::TypeInfo> {
+    #[view]
+    public fun lz_receive_types(_src_chain_id: u64, _src_address: vector<u8>, _payload: vector<u8>) : vector<type_info::TypeInfo> {
         vector::empty<type_info::TypeInfo>()
     }
 

--- a/apps/counter/sources/counter.move
+++ b/apps/counter/sources/counter.move
@@ -28,7 +28,10 @@ module counter::counter {
         lzapp::init(account, cap);
         remote::init(account);
 
+        let i:u64 = 0;
+
         move_to(account, Capabilities { cap });
+        move_to(account, Counter { i })
     }
 
     /// create_counter a `Counter` resource with value `i` under the given `account`


### PR DESCRIPTION
1. `lz_receive_types`
Error - Entry functions cannot return values but this function is a entry function and is returning value.
<img width="1028" alt="Screenshot 2024-02-23 at 6 05 57 PM" src="https://github.com/LayerZero-Labs/LayerZero-Aptos-Contract/assets/59167439/ef24615f-f0d0-4479-ab33-31fbd01f50b0">
Fix - Made this a view function and removed entry.
<img width="966" alt="Screenshot 2024-02-23 at 6 10 22 PM" src="https://github.com/LayerZero-Labs/LayerZero-Aptos-Contract/assets/59167439/81587157-ecf7-47e5-8081-501d32870f75">



2. `Counter` resource 
Error - This resource gets incremented in `lz_receive_internal` for counter account but it is not getting created anywhere and there is no option to create a `Counter` resource for counter module
<img width="1028" alt="Screenshot 2024-02-23 at 6 06 04 PM" src="https://github.com/LayerZero-Labs/LayerZero-Aptos-Contract/assets/59167439/0f594b93-6cb9-40b6-9d3c-bf8c37afc81b">
Fix - Created a counter resource in init_module for counter account
<img width="437" alt="Screenshot 2024-02-23 at 6 10 12 PM" src="https://github.com/LayerZero-Labs/LayerZero-Aptos-Contract/assets/59167439/59296467-8126-4c86-8f21-0ee27f32c754">

